### PR TITLE
[sql-table-alias] Add explanation for omision of `AS` keyword

### DIFF
--- a/src/posts/sql-table-alias/index.md
+++ b/src/posts/sql-table-alias/index.md
@@ -26,3 +26,10 @@ could be re-written as:
  ```
  
 This allows us to use the alias ("p" in our example) instead of typing out the full table name each time.
+
+We can even omit the **AS** keyword, if the table name is immediately followed by its alias:
+
+```sql
+ SELECT p.description, p.category, p.price
+ FROM Products p;
+ ```


### PR DESCRIPTION
Hi, thanks for the tutorial!
I noticed that the proposed solution on the [table-alias](https://sqlcrashcourse.com/sql-table-alias/) chapter shows usage of ALIAS while omiting the 'AS' keyword; I added a short explanation to the theory section.