### PR TITLE
small in-text styling fix 

### DIFF
--- a/src/posts/sql-delete/index.md
+++ b/src/posts/sql-delete/index.md
@@ -50,7 +50,7 @@ No filtering on a non-existent **WHERE** clause so **SQL** just assumes you want
 
 But no-one would be that stupid you say &#8211; would they? Oh hell yes they would. We all have been.
 
-Under pressure, rushing something out, not paying quite as much attention as we should and BOOM._ **It&#8217;s all gone**_.
+Under pressure, rushing something out, not paying quite as much attention as we should and BOOM. _**It&#8217;s all gone**_.
 
 ## Please be careful.
 

--- a/src/posts/sql-delete/index.md
+++ b/src/posts/sql-delete/index.md
@@ -61,5 +61,3 @@ Now, there may be times when you do legitimately want to scrub all records from 
 No-one needs the pain of sitting up all night trying to re-create a table from backups and log files and praying you get it close enough that no-ones really notices what you did.
 
 ### This is experience talking. Listen to it.
-
-<a href="/the-end" className="link-button">Try the next lesson</a>

--- a/src/posts/sql-insert-into/index.md
+++ b/src/posts/sql-insert-into/index.md
@@ -51,5 +51,3 @@ VALUES ('Jimmy', 'Page', 'Led Zeppelin', 'Gibson', 'Les Paul', 'England');
 ```
 
 And now you have one of the pioneers of heavy rock in your database table.
-
-<a href="/sql-update" className="link-button">Try the next lesson</a>

--- a/src/posts/sql-update/index.md
+++ b/src/posts/sql-update/index.md
@@ -48,5 +48,3 @@ By adding the **WHERE** clause we have limited the **UPDATE** to only those empl
 The **WHERE** clause is always a useful one to keep an eye on. There isn&#8217;t a SQL developer in the world who hasn&#8217;t got carried away and updated every row in their database by accident when they should have used the **WHERE** clause to filter their targets.
 
 You should have plenty of experience with **WHERE** by now after all of the previous lessons but it's always worth a refresher if you aren't sure. Better safe than (very) sorry.
-
-<a href="/sql-delete" className="link-button">Try the next lesson</a>


### PR DESCRIPTION
The words "It's all gone" on the Lesson 35: The SQL DELETE Statement page had underscores on either side showing up in the view. I fixed it so it looks bold and italicized as intended. Very minor fix.